### PR TITLE
Distinguish frameworks added before and after the blog post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 elm-stuff
 node_modules
+picker.js
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -28,29 +28,30 @@
   </div>
 
   <script type="text/javascript">
-    function impl(name, version, optimized, url)
+    function impl(name, version, optimized, url, afterBlogPost)
     {
       return {
         name: name,
         version: version,
         optimized: optimized,
-        url: 'implementations/' + url
+        url: 'implementations/' + url,
+        afterBlogPost: afterBlogPost
       };
     }
 
     var div = document.getElementById('sidebar');
     var picker = Elm.Picker.embed(div, [
-      impl('Ember', '2.6.3', false, 'ember-2.6.3/dist/index.html'),
-      impl('React', '15.3.1', false, 'react-15.3.1/index.html'),
-      impl('Angular', '1.5.8', false, 'angular-1.5.8/index.html'),
-      impl('Angular', '2', false, 'angular-2/index.html'),
-      impl('Elm', '0.16', false, 'elm-0.16/index.html'),
-      impl('Elm', '0.17', false, 'elm-0.17/index.html'),
-      impl('React', '15.3.1', true, 'react-15.3.1-optimized/index.html'),
-      impl('Angular', '1.5.8', true, 'angular-1.5.8-optimized/index.html'),
-      impl('Angular', '2', true, 'angular-2-optimized/index.html'),
-      impl('Elm', '0.16', true, 'elm-0.16-optimized/index.html'),
-      impl('Elm', '0.17', true, 'elm-0.17-optimized/index.html')
+      impl('Ember', '2.6.3', false, 'ember-2.6.3/dist/index.html', false),
+      impl('React', '15.3.1', false, 'react-15.3.1/index.html', false),
+      impl('Angular', '1.5.8', false, 'angular-1.5.8/index.html', false),
+      impl('Angular', '2', false, 'angular-2/index.html', false),
+      impl('Elm', '0.16', false, 'elm-0.16/index.html', false),
+      impl('Elm', '0.17', false, 'elm-0.17/index.html', false),
+      impl('React', '15.3.1', true, 'react-15.3.1-optimized/index.html', false),
+      impl('Angular', '1.5.8', true, 'angular-1.5.8-optimized/index.html', false),
+      impl('Angular', '2', true, 'angular-2-optimized/index.html', false),
+      impl('Elm', '0.16', true, 'elm-0.16-optimized/index.html', false),
+      impl('Elm', '0.17', true, 'elm-0.17-optimized/index.html', false)
     ]);
 
     picker.ports.start.subscribe(function(impls) {

--- a/index.html
+++ b/index.html
@@ -25,6 +25,8 @@
     </p>
     <p>Check out <a href="http://elm-lang.org/blog/blazing-fast-html-round-two">this blog post</a> for more information on the methodology we used to make these comparisons as fair as possible.
     </p>
+    <h4>Note</h4>
+    <p>Some frameworks or versions listed to the right have been added subsequent to the blog post being posted, allowing future implementations to be compared with newer versions of Elm.</p>
   </div>
 
   <script type="text/javascript">

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,9 @@ If you want to fork this repo and try things out, the easiest way is probably to
 
 ```bash
 cd src
-elm-make Picker.elm --output=picker.js
+npm install
+# Uses Elm 0.18 instead of global package:
+npm run make
 ```
 
 And then navigate into `implementations/*/readme.md` and follow the build instructions for the various projects.

--- a/src/Picker.elm
+++ b/src/Picker.elm
@@ -115,13 +115,29 @@ subscriptions model =
 view : Model -> Html Msg
 view { running, entries } =
     div []
-        [ ul
+        [ h2 [] [ text "Before Blog Post" ]
+        , ul
             (if running then
                 [ style [ ( "color", "#aaa" ) ] ]
              else
                 []
             )
-            (List.map (viewEntry running) entries)
+            (entries
+                |> List.filter (\entry -> not entry.impl.afterBlogPost)
+                |> List.map (viewEntry running)
+            )
+        , hr [] []
+        , h2 [] [ text "After Blog Post" ]
+        , ul
+            (if running then
+                [ style [ ( "color", "#aaa" ) ] ]
+             else
+                []
+            )
+            (entries
+                |> List.filter (\entry -> entry.impl.afterBlogPost)
+                |> List.map (viewEntry running)
+            )
         , button
             [ style [ ( "width", "100%" ) ]
             , disabled running

--- a/src/Picker.elm
+++ b/src/Picker.elm
@@ -49,7 +49,6 @@ init impls =
         ! []
 
 
-
 -- UPDATE
 
 
@@ -93,7 +92,10 @@ port start : List Impl -> Cmd msg
 
 startSelected : List Entry -> Cmd msg
 startSelected entries =
-    start (List.map .impl (List.filter .selected entries))
+    entries
+        |> List.filter .selected
+        |> List.map .impl
+        |> start
 
 
 

--- a/src/Picker.elm
+++ b/src/Picker.elm
@@ -117,6 +117,20 @@ subscriptions model =
 
 view : Model -> Html Msg
 view { running, entries } =
+    div [] <|
+        (viewEarlyEntries running entries)
+            ++ (viewLaterEntries running entries)
+            ++ [ button
+                    [ style [ ( "width", "100%" ) ]
+                    , disabled running
+                    , onClick Start
+                    ]
+                    [ text "Run" ]
+               ]
+
+
+viewEarlyEntries : Bool -> List Entry -> List (Html Msg)
+viewEarlyEntries running entries =
     let
         earlyEntries =
             entries |> List.filter (\entry -> not entry.impl.afterBlogPost)
@@ -124,41 +138,40 @@ view { running, entries } =
         laterEntries =
             entries |> List.filter (\entry -> entry.impl.afterBlogPost)
     in
-        div [] <|
-            [ h2 [] [ text "Before Blog Post" ]
+        (if List.isEmpty laterEntries then
+            []
+         else
+            [ h2 [] [ text "Before Blog Post" ] ]
+        )
+            ++ [ ul
+                    (if running then
+                        [ style [ ( "color", "#aaa" ) ] ]
+                     else
+                        []
+                    )
+                    (List.map (viewEntry running) earlyEntries)
+               ]
+
+
+viewLaterEntries : Bool -> List Entry -> List (Html Msg)
+viewLaterEntries running entries =
+    let
+        laterEntries =
+            entries |> List.filter (\entry -> entry.impl.afterBlogPost)
+    in
+        if List.isEmpty laterEntries then
+            []
+        else
+            [ hr [] []
+            , h2 [] [ text "After Blog Post" ]
             , ul
                 (if running then
                     [ style [ ( "color", "#aaa" ) ] ]
                  else
                     []
                 )
-                (List.map (viewEntry running) earlyEntries)
+                (List.map (viewEntry running) laterEntries)
             ]
-                ++ (viewLaterEntries running laterEntries)
-                ++ [ button
-                        [ style [ ( "width", "100%" ) ]
-                        , disabled running
-                        , onClick Start
-                        ]
-                        [ text "Run" ]
-                   ]
-
-
-viewLaterEntries : Bool -> List Entry -> List (Html Msg)
-viewLaterEntries running entries =
-    if List.isEmpty entries then
-        []
-    else
-        [ hr [] []
-        , h2 [] [ text "After Blog Post" ]
-        , ul
-            (if running then
-                [ style [ ( "color", "#aaa" ) ] ]
-             else
-                []
-            )
-            (List.map (viewEntry running) entries)
-        ]
 
 
 viewEntry : Bool -> Entry -> Html Msg

--- a/src/Picker.elm
+++ b/src/Picker.elm
@@ -49,6 +49,7 @@ init impls =
         ! []
 
 
+
 -- UPDATE
 
 
@@ -116,37 +117,38 @@ subscriptions model =
 
 view : Model -> Html Msg
 view { running, entries } =
-    div []
-        [ h2 [] [ text "Before Blog Post" ]
-        , ul
-            (if running then
-                [ style [ ( "color", "#aaa" ) ] ]
-             else
-                []
-            )
-            (entries
-                |> List.filter (\entry -> not entry.impl.afterBlogPost)
-                |> List.map (viewEntry running)
-            )
-        , hr [] []
-        , h2 [] [ text "After Blog Post" ]
-        , ul
-            (if running then
-                [ style [ ( "color", "#aaa" ) ] ]
-             else
-                []
-            )
-            (entries
-                |> List.filter (\entry -> entry.impl.afterBlogPost)
-                |> List.map (viewEntry running)
-            )
-        , button
-            [ style [ ( "width", "100%" ) ]
-            , disabled running
-            , onClick Start
+    let
+        earlyEntries =
+            entries |> List.filter (\entry -> not entry.impl.afterBlogPost)
+
+        laterEntries =
+            entries |> List.filter (\entry -> entry.impl.afterBlogPost)
+    in
+        div []
+            [ h2 [] [ text "Before Blog Post" ]
+            , ul
+                (if running then
+                    [ style [ ( "color", "#aaa" ) ] ]
+                 else
+                    []
+                )
+                (List.map (viewEntry running) earlyEntries)
+            , hr [] []
+            , h2 [] [ text "After Blog Post" ]
+            , ul
+                (if running then
+                    [ style [ ( "color", "#aaa" ) ] ]
+                 else
+                    []
+                )
+                (List.map (viewEntry running) laterEntries)
+            , button
+                [ style [ ( "width", "100%" ) ]
+                , disabled running
+                , onClick Start
+                ]
+                [ text "Run" ]
             ]
-            [ text "Run" ]
-        ]
 
 
 viewEntry : Bool -> Entry -> Html Msg

--- a/src/Picker.elm
+++ b/src/Picker.elm
@@ -124,7 +124,7 @@ view { running, entries } =
         laterEntries =
             entries |> List.filter (\entry -> entry.impl.afterBlogPost)
     in
-        div []
+        div [] <|
             [ h2 [] [ text "Before Blog Post" ]
             , ul
                 (if running then
@@ -133,22 +133,32 @@ view { running, entries } =
                     []
                 )
                 (List.map (viewEntry running) earlyEntries)
-            , hr [] []
-            , h2 [] [ text "After Blog Post" ]
-            , ul
-                (if running then
-                    [ style [ ( "color", "#aaa" ) ] ]
-                 else
-                    []
-                )
-                (List.map (viewEntry running) laterEntries)
-            , button
-                [ style [ ( "width", "100%" ) ]
-                , disabled running
-                , onClick Start
-                ]
-                [ text "Run" ]
             ]
+                ++ (viewLaterEntries running laterEntries)
+                ++ [ button
+                        [ style [ ( "width", "100%" ) ]
+                        , disabled running
+                        , onClick Start
+                        ]
+                        [ text "Run" ]
+                   ]
+
+
+viewLaterEntries : Bool -> List Entry -> List (Html Msg)
+viewLaterEntries running entries =
+    if List.isEmpty entries then
+        []
+    else
+        [ hr [] []
+        , h2 [] [ text "After Blog Post" ]
+        , ul
+            (if running then
+                [ style [ ( "color", "#aaa" ) ] ]
+             else
+                []
+            )
+            (List.map (viewEntry running) entries)
+        ]
 
 
 viewEntry : Bool -> Entry -> Html Msg

--- a/src/Picker.elm
+++ b/src/Picker.elm
@@ -37,6 +37,7 @@ type alias Impl =
     , version : String
     , url : String
     , optimized : Bool
+    , afterBlogPost : Bool
     }
 
 

--- a/src/Picker.elm
+++ b/src/Picker.elm
@@ -6,14 +6,13 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 
 
-
 main =
-  App.programWithFlags
-    { init = init
-    , view = view
-    , update = update
-    , subscriptions = subscriptions
-    }
+    App.programWithFlags
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = subscriptions
+        }
 
 
 
@@ -21,32 +20,32 @@ main =
 
 
 type alias Model =
-  { running : Bool
-  , entries : List Entry
-  }
+    { running : Bool
+    , entries : List Entry
+    }
 
 
 type alias Entry =
-  { selected : Bool
-  , id : Int
-  , impl : Impl
-  }
+    { selected : Bool
+    , id : Int
+    , impl : Impl
+    }
 
 
 type alias Impl =
-  { name : String
-  , version : String
-  , url : String
-  , optimized : Bool
-  }
+    { name : String
+    , version : String
+    , url : String
+    , optimized : Bool
+    }
 
 
 init : List Impl -> ( Model, Cmd msg )
 init impls =
-  { running = False
-  , entries = List.indexedMap (Entry False) impls
-  }
-    ! []
+    { running = False
+    , entries = List.indexedMap (Entry False) impls
+    }
+        ! []
 
 
 
@@ -54,39 +53,38 @@ init impls =
 
 
 type Msg
-  = Toggle Int
-  | Start
-  | End
+    = Toggle Int
+    | Start
+    | End
 
 
 update : Msg -> Model -> ( Model, Cmd msg )
 update msg model =
-  case msg of
-    Toggle id ->
-      { model | entries = toggle id model.entries }
-        ! []
+    case msg of
+        Toggle id ->
+            { model | entries = toggle id model.entries }
+                ! []
 
-    Start ->
-      { model | running = True }
-        ! [ startSelected model.entries ]
+        Start ->
+            { model | running = True }
+                ! [ startSelected model.entries ]
 
-    End ->
-      { model | running = False }
-        ! []
+        End ->
+            { model | running = False }
+                ! []
 
 
 toggle : Int -> List Entry -> List Entry
 toggle id entries =
-  case entries of
-    [] ->
-      []
+    case entries of
+        [] ->
+            []
 
-    entry :: rest ->
-      if entry.id == id then
-        { entry | selected = not entry.selected } :: rest
-
-      else
-        entry :: toggle id rest
+        entry :: rest ->
+            if entry.id == id then
+                { entry | selected = not entry.selected } :: rest
+            else
+                entry :: toggle id rest
 
 
 port start : List Impl -> Cmd msg
@@ -94,7 +92,7 @@ port start : List Impl -> Cmd msg
 
 startSelected : List Entry -> Cmd msg
 startSelected entries =
-  start (List.map .impl (List.filter .selected entries))
+    start (List.map .impl (List.filter .selected entries))
 
 
 
@@ -106,7 +104,7 @@ port end : (() -> msg) -> Sub msg
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-  end (always End)
+    end (always End)
 
 
 
@@ -115,33 +113,46 @@ subscriptions model =
 
 view : Model -> Html Msg
 view { running, entries } =
-  div []
-    [ ul
-        (if running then [ style [("color", "#aaa")] ] else [])
-        (List.map (viewEntry running) entries)
-    , button
-        [ style [("width","100%")]
-        , disabled running
-        , onClick Start
+    div []
+        [ ul
+            (if running then
+                [ style [ ( "color", "#aaa" ) ] ]
+             else
+                []
+            )
+            (List.map (viewEntry running) entries)
+        , button
+            [ style [ ( "width", "100%" ) ]
+            , disabled running
+            , onClick Start
+            ]
+            [ text "Run" ]
         ]
-        [ text "Run" ]
-    ]
 
 
 viewEntry : Bool -> Entry -> Html Msg
 viewEntry running { id, selected, impl } =
-  li
-    (if running then [ pointer ] else [ pointer, onClick (Toggle id) ])
-    [ input [ type' "checkbox", checked selected, disabled running ] []
-    , text (" " ++ impl.name ++ " " ++ impl.version)
-    , span
-        [ style [("color","#aaa")]
+    li
+        (if running then
+            [ pointer ]
+         else
+            [ pointer, onClick (Toggle id) ]
+        )
+        [ input [ type' "checkbox", checked selected, disabled running ] []
+        , text (" " ++ impl.name ++ " " ++ impl.version)
+        , span
+            [ style [ ( "color", "#aaa" ) ]
+            ]
+            [ text
+                (if impl.optimized then
+                    " (optimized)"
+                 else
+                    ""
+                )
+            ]
         ]
-        [ text (if impl.optimized then " (optimized)" else "")
-        ]
-    ]
 
 
 pointer : Attribute msg
 pointer =
-  style [ ("cursor", "pointer") ]
+    style [ ( "cursor", "pointer" ) ]

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "src",
+  "version": "1.0.0",
+  "description": "",
+  "main": "add-complete-delete-batched.js",
+  "scripts": {
+    "make": "npx elm make Picker.elm --output=picker.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "elm": "^0.17.1"
+  }
+}


### PR DESCRIPTION
Per this [comment](https://github.com/evancz/react-angular-ember-elm-performance-comparison/pull/12#issuecomment-248167628), I took a stab at delineating between frameworks that were a part of the initial analysis versus those that have since been added. This should clear a path towards adding new frameworks/versions for more consistent benchmark testing.

Sidebar before (Or when there are zero "later entries"):
<img width="236" alt="zero later-entries" src="https://user-images.githubusercontent.com/4212194/44629682-e3c22800-a920-11e8-951d-073c30f780aa.png">


After (Or when there are greater than zero "later entries"):
<img width="224" alt="with some later-entries" src="https://user-images.githubusercontent.com/4212194/44629601-be80ea00-a91f-11e8-9e38-edb225e7140e.png">

All one needs to do is add a boolean flag to the corresponding `impl` call in `index.html`.